### PR TITLE
Corrected Amethyst for deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ powerful cross-platform games. [[source]](https://github.com/MonoGame/MonoGame)
 
 ## Rust
 
-- **[Amethyst](https://amethyst.rs)** - Data-driven game engine written in Rust. [[source]](https://github.com/amethyst/amethyst)
+- **[Amethyst]** - DEPRECATED - Data-driven game engine written in Rust. [[source]](https://github.com/amethyst/amethyst)
 
 - **[Bevy](https://bevyengine.org)** - A refreshingly simple data-driven game engine built in Rust. [[source]](https://github.com/bevyengine/bevy)
 


### PR DESCRIPTION
Amethyst game engine has been concluded. The repo still exists as an archive at the github link, but has been closed since 2022.