### PR TITLE
Add Solar2D

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ powerful cross-platform games. [[source]](https://github.com/MonoGame/MonoGame)
 
 - **[LÖVE](https://love2d.org)** - An *awesome* framework you can use to make 2D games in Lua. [[source]](https://github.com/love2d/love)
 
+- **[Solar2D](https://solar2d.com/)** - Solar2D is a Lua based game engine formally called [Corona SDK](https://coronalabs.com/) with focus on ease of iterations and usage [[source]](https://github.com/coronalabs/corona)
+
 - **[Gideros](https://www.gideros.rocks/)** - A complete framework you can use to make 2D games and apps in Lua with instant on-device testing: exports to Windows, Linux, MacOs, iOS, Android, HTML5. [[source]](https://github.com/gideros/gideros)
 
 ## Pascal


### PR DESCRIPTION
I would like to please propose that you add Solar2D in your list

[Solar2D](https://solar2d.com/) is based on the defunct [CoronaSDK](https://coronalabs.com/) which appears to have been stopped.

The [[source]](https://github.com/coronalabs/corona) code is available and appears to be newly changing.
